### PR TITLE
add th_timestamp field to alert_actions

### DIFF
--- a/TA_thehive_ce/README/alert_actions.conf.spec
+++ b/TA_thehive_ce/README/alert_actions.conf.spec
@@ -18,4 +18,4 @@ param.th_tags = <string> Tag(s).
 param.th_type = <string> Type.
 param.th_unique_id = <string> Unique ID.
 param._cam = <json> Active response parameters.
-
+param.th_timestamp = <string> Timestamp

--- a/TA_thehive_ce/default/alert_actions.conf
+++ b/TA_thehive_ce/default/alert_actions.conf
@@ -19,4 +19,5 @@ is_custom = 1
 param.th_severity = 3
 param.th_tlp = 2
 param.th_pap = 2
+param.th_timestamp = 
 command = sendalert $action_name$ results_file="$results.file$" results_link="$results.url$" param.action_name=$action_name$ | stats count


### PR DESCRIPTION
Quick adaptive action requires all fields to be presented in alert_actions.conf, otherwise it will just error: `ModularActionException: Invalid parameter for adhoc modular action.`